### PR TITLE
Add guard on Window.Run

### DIFF
--- a/SharpEngine.Core/Window.cs
+++ b/SharpEngine.Core/Window.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Raylib_cs;
@@ -297,6 +298,12 @@ public class Window
         StartCallback?.Invoke(this, args);
         if (!args.Result)
             return;
+
+        if (!Scenes.Any())
+        {
+            DebugManager.Log(LogLevel.LogError, "SE: There are no scenes in window.");
+            return;
+        }
 
         #region Load
 


### PR DESCRIPTION
Add guard on Window.Run to ensure that there is at least one scene.

Without the guard  the execution failed with an exception when trying to open current scene: `CurrentScene.OpenScene();`